### PR TITLE
[jovian] extend extraData to include `minBaseFeeLog2` in EIP1559Params

### DIFF
--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -110,13 +110,11 @@ pub fn encode_jovian_extra_data(
             .try_into()
             .map_err(|_| EIP1559ParamError::ElasticityOverflow)?;
 
-        // Not Jovian so set it to 0
-        let min_base_fee_log2: u8 = 0;
-
         // Copy the values safely
         extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
         extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
-        extra_data[9] = min_base_fee_log2;
+        // Not Jovian so set it to 0
+        extra_data[9] = 0;
     } else {
         let (elasticity, denominator, min_base_fee_log2) =
             decode_jovian_eip_1559_params(eip_1559_params);

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -1,7 +1,7 @@
 //! Support for EIP-1559 parameters after holocene.
 
 use alloy_eips::eip1559::BaseFeeParams;
-use alloy_primitives::{B64, Bytes};
+use alloy_primitives::{B64, Bytes, aliases::B96};
 
 /// Extracts the Holocene 1599 parameters from the encoded form:
 /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip1559params-encoding>
@@ -61,6 +61,72 @@ pub fn encode_holocene_extra_data(
     Ok(Bytes::copy_from_slice(&extra_data))
 }
 
+/// Decodes the Jovian 1599 parameters from the encoded form:
+/// [TODO link design doc]
+///
+/// Returns (`elasticity`, `denominator`, `min_base_fee_log2`)
+pub fn decode_jovian_eip_1559_params(eip_1559_params: B96) -> (u32, u32, u8) {
+    let denominator: [u8; 4] = eip_1559_params.0[..4].try_into().expect("sufficient length");
+    let elasticity: [u8; 4] = eip_1559_params.0[4..8].try_into().expect("sufficient length");
+    let min_base_fee_log2: u8 = eip_1559_params.0[8];
+
+    (u32::from_be_bytes(elasticity), u32::from_be_bytes(denominator), min_base_fee_log2)
+}
+
+/// Decodes the Jovian 1599 parameters from the `extradata` bytes.
+///
+/// Returns (`elasticity`, `denominator`, `min_base_fee_log2`)
+pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u8), EIP1559ParamError> {
+    if extra_data.len() < 10 {
+        return Err(EIP1559ParamError::NoEIP1559Params);
+    }
+
+    if extra_data[0] != 1 {
+        // version must be 1: [TODO link design doc]
+        return Err(EIP1559ParamError::InvalidVersion(extra_data[0]));
+    }
+
+    Ok(decode_jovian_eip_1559_params(B96::from_slice(&extra_data[1..10])))
+}
+
+/// Encodes the Jovian 1599 parameters for the payload.
+pub fn encode_jovian_extra_data(
+    eip_1559_params: B96,
+    default_base_fee_params: BaseFeeParams,
+) -> Result<Bytes, EIP1559ParamError> {
+    // 10 bytes: 1 byte for version (1) and 9 bytes for eip1559 params
+    let mut extra_data = [0u8; 10];
+    extra_data[0] = 1;
+    // If eip 1559 params aren't set, use the canyon base fee param constants
+    // otherwise use them
+    if eip_1559_params.is_zero() {
+        // Try casting max_change_denominator to u32
+        let max_change_denominator: u32 = (default_base_fee_params.max_change_denominator)
+            .try_into()
+            .map_err(|_| EIP1559ParamError::DenominatorOverflow)?;
+
+        // Try casting elasticity_multiplier to u32
+        let elasticity_multiplier: u32 = (default_base_fee_params.elasticity_multiplier)
+            .try_into()
+            .map_err(|_| EIP1559ParamError::ElasticityOverflow)?;
+
+        // Not Jovian so set it to 0
+        let min_base_fee_log2: u8 = 0;
+
+        // Copy the values safely
+        extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
+        extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
+        extra_data[9] = min_base_fee_log2;
+    } else {
+        let (elasticity, denominator, min_base_fee_log2) =
+            decode_jovian_eip_1559_params(eip_1559_params);
+        extra_data[1..5].copy_from_slice(&denominator.to_be_bytes());
+        extra_data[5..9].copy_from_slice(&elasticity.to_be_bytes());
+        extra_data[9] = min_base_fee_log2;
+    }
+    Ok(Bytes::copy_from_slice(&extra_data))
+}
+
 /// Error type for EIP-1559 parameters
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 pub enum EIP1559ParamError {
@@ -95,5 +161,19 @@ mod tests {
         let eip_1559_params = B64::ZERO;
         let extra_data = encode_holocene_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[0, 0, 0, 0, 80, 0, 0, 0, 60]));
+    }
+
+    #[test]
+    fn test_get_extra_data_jovian() {
+        let eip_1559_params = B96::from_str("0x000000080000000801000000").unwrap();
+        let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
+        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8, 1]));
+    }
+
+    #[test]
+    fn test_get_extra_data_jovian_default() {
+        let eip_1559_params = B96::ZERO;
+        let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
+        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0]));
     }
 }

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -3,6 +3,31 @@
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::{B64, Bytes};
 
+/// Encodes the `eip1559` parameters for the payload.
+fn encode_eip_1559_params(
+    eip_1559_params: B64,
+    default_base_fee_params: BaseFeeParams,
+    extra_data: &mut [u8],
+) -> Result<(), EIP1559ParamError> {
+    if eip_1559_params.is_zero() {
+        let max_change_denominator: u32 = (default_base_fee_params.max_change_denominator)
+            .try_into()
+            .map_err(|_| EIP1559ParamError::DenominatorOverflow)?;
+
+        let elasticity_multiplier: u32 = (default_base_fee_params.elasticity_multiplier)
+            .try_into()
+            .map_err(|_| EIP1559ParamError::ElasticityOverflow)?;
+
+        extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
+        extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
+    } else {
+        let (elasticity, denominator) = decode_eip_1559_params(eip_1559_params);
+        extra_data[1..5].copy_from_slice(&denominator.to_be_bytes());
+        extra_data[5..9].copy_from_slice(&elasticity.to_be_bytes());
+    }
+    Ok(())
+}
+
 /// Extracts the Holocene 1599 parameters from the encoded form:
 /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip1559params-encoding>
 ///
@@ -37,27 +62,7 @@ pub fn encode_holocene_extra_data(
 ) -> Result<Bytes, EIP1559ParamError> {
     // 9 bytes: 1 byte for version (0) and 8 bytes for eip1559 params
     let mut extra_data = [0u8; 9];
-    // If eip 1559 params aren't set, use the canyon base fee param constants
-    // otherwise use them
-    if eip_1559_params.is_zero() {
-        // Try casting max_change_denominator to u32
-        let max_change_denominator: u32 = (default_base_fee_params.max_change_denominator)
-            .try_into()
-            .map_err(|_| EIP1559ParamError::DenominatorOverflow)?;
-
-        // Try casting elasticity_multiplier to u32
-        let elasticity_multiplier: u32 = (default_base_fee_params.elasticity_multiplier)
-            .try_into()
-            .map_err(|_| EIP1559ParamError::ElasticityOverflow)?;
-
-        // Copy the values safely
-        extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
-        extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
-    } else {
-        let (elasticity, denominator) = decode_eip_1559_params(eip_1559_params);
-        extra_data[1..5].copy_from_slice(&denominator.to_be_bytes());
-        extra_data[5..9].copy_from_slice(&elasticity.to_be_bytes());
-    }
+    encode_eip_1559_params(eip_1559_params, default_base_fee_params, &mut extra_data)?;
     Ok(Bytes::copy_from_slice(&extra_data))
 }
 
@@ -70,27 +75,7 @@ pub fn encode_jovian_extra_data(
     // 9 bytes: 1 byte for version (1) and 8 bytes for eip1559 params
     let mut extra_data = [0u8; 9];
     extra_data[0] = 1;
-    // If eip 1559 params aren't set, use the canyon base fee param constants
-    // otherwise use them
-    if eip_1559_params.is_zero() {
-        // Try casting max_change_denominator to u32
-        let max_change_denominator: u32 = (default_base_fee_params.max_change_denominator)
-            .try_into()
-            .map_err(|_| EIP1559ParamError::DenominatorOverflow)?;
-
-        // Try casting elasticity_multiplier to u32
-        let elasticity_multiplier: u32 = (default_base_fee_params.elasticity_multiplier)
-            .try_into()
-            .map_err(|_| EIP1559ParamError::ElasticityOverflow)?;
-
-        // Copy the values safely
-        extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
-        extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
-    } else {
-        let (elasticity, denominator) = decode_eip_1559_params(eip_1559_params);
-        extra_data[1..5].copy_from_slice(&denominator.to_be_bytes());
-        extra_data[5..9].copy_from_slice(&elasticity.to_be_bytes());
-    }
+    encode_eip_1559_params(eip_1559_params, default_base_fee_params, &mut extra_data)?;
     Ok(Bytes::copy_from_slice(&extra_data))
 }
 
@@ -134,6 +119,7 @@ mod tests {
     fn test_get_extra_data_jovian() {
         let eip_1559_params = B64::from_str("0x0000000800000008").unwrap();
         let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
+        // specifically check the version byte is 1
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8]));
     }
 
@@ -141,6 +127,7 @@ mod tests {
     fn test_get_extra_data_jovian_default() {
         let eip_1559_params = B64::ZERO;
         let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
+        // specifically check the version byte is 1
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60]));
     }
 }

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -1,7 +1,7 @@
 //! Support for EIP-1559 parameters after holocene.
 
 use alloy_eips::eip1559::BaseFeeParams;
-use alloy_primitives::{B64, Bytes, FixedBytes};
+use alloy_primitives::{B64, Bytes};
 
 /// Extracts the Holocene 1599 parameters from the encoded form:
 /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip1559params-encoding>
@@ -61,41 +61,14 @@ pub fn encode_holocene_extra_data(
     Ok(Bytes::copy_from_slice(&extra_data))
 }
 
-/// Decodes the Jovian 1599 parameters from the encoded form:
-/// <https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md>
-///
-/// Returns (`elasticity`, `denominator`, `min_base_fee_log2`)
-pub fn decode_jovian_eip_1559_params(eip_1559_params: FixedBytes<9>) -> (u32, u32, u8) {
-    let denominator: [u8; 4] = eip_1559_params.0[..4].try_into().expect("sufficient length");
-    let elasticity: [u8; 4] = eip_1559_params.0[4..8].try_into().expect("sufficient length");
-    let min_base_fee_log2: u8 = eip_1559_params.0[8];
-
-    (u32::from_be_bytes(elasticity), u32::from_be_bytes(denominator), min_base_fee_log2)
-}
-
-/// Decodes the Jovian 1599 parameters from the `extradata` bytes.
-///
-/// Returns (`elasticity`, `denominator`, `min_base_fee_log2`)
-pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u8), EIP1559ParamError> {
-    if extra_data.len() < 10 {
-        return Err(EIP1559ParamError::NoEIP1559Params);
-    }
-
-    if extra_data[0] != 1 {
-        // version must be 1: <https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md#minimum-base-fee-in-block-header>
-        return Err(EIP1559ParamError::InvalidVersion(extra_data[0]));
-    }
-
-    Ok(decode_jovian_eip_1559_params(FixedBytes::from_slice(&extra_data[1..10])))
-}
-
-/// Encodes the Jovian 1599 parameters for the payload.
+/// Encodes the Jovian 1599 parameters for the payload, specifically setting
+/// the version byte to 1.
 pub fn encode_jovian_extra_data(
-    eip_1559_params: FixedBytes<9>,
+    eip_1559_params: B64,
     default_base_fee_params: BaseFeeParams,
 ) -> Result<Bytes, EIP1559ParamError> {
-    // 10 bytes: 1 byte for version (1) and 9 bytes for eip1559 params
-    let mut extra_data = [0u8; 10];
+    // 9 bytes: 1 byte for version (1) and 8 bytes for eip1559 params
+    let mut extra_data = [0u8; 9];
     extra_data[0] = 1;
     // If eip 1559 params aren't set, use the canyon base fee param constants
     // otherwise use them
@@ -113,14 +86,10 @@ pub fn encode_jovian_extra_data(
         // Copy the values safely
         extra_data[1..5].copy_from_slice(&max_change_denominator.to_be_bytes());
         extra_data[5..9].copy_from_slice(&elasticity_multiplier.to_be_bytes());
-        // Not Jovian so set it to 0
-        extra_data[9] = 0;
     } else {
-        let (elasticity, denominator, min_base_fee_log2) =
-            decode_jovian_eip_1559_params(eip_1559_params);
+        let (elasticity, denominator) = decode_eip_1559_params(eip_1559_params);
         extra_data[1..5].copy_from_slice(&denominator.to_be_bytes());
         extra_data[5..9].copy_from_slice(&elasticity.to_be_bytes());
-        extra_data[9] = min_base_fee_log2;
     }
     Ok(Bytes::copy_from_slice(&extra_data))
 }
@@ -163,15 +132,15 @@ mod tests {
 
     #[test]
     fn test_get_extra_data_jovian() {
-        let eip_1559_params = FixedBytes::from_str("0x000000080000000801").unwrap();
+        let eip_1559_params = B64::from_str("0x0000000800000008").unwrap();
         let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
-        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8, 1]));
+        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8]));
     }
 
     #[test]
     fn test_get_extra_data_jovian_default() {
-        let eip_1559_params = FixedBytes::ZERO;
+        let eip_1559_params = B64::ZERO;
         let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60));
-        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0]));
+        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60]));
     }
 }

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -62,7 +62,7 @@ pub fn encode_holocene_extra_data(
 }
 
 /// Decodes the Jovian 1599 parameters from the encoded form:
-/// [TODO link design doc]
+/// <https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md>
 ///
 /// Returns (`elasticity`, `denominator`, `min_base_fee_log2`)
 pub fn decode_jovian_eip_1559_params(eip_1559_params: FixedBytes<9>) -> (u32, u32, u8) {
@@ -82,7 +82,7 @@ pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u8), EIP
     }
 
     if extra_data[0] != 1 {
-        // version must be 1: [TODO link design doc]
+        // version must be 1: <https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md#minimum-base-fee-in-block-header>
         return Err(EIP1559ParamError::InvalidVersion(extra_data[0]));
     }
 

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -66,26 +66,14 @@ pub fn encode_holocene_extra_data(
     Ok(Bytes::copy_from_slice(&extra_data))
 }
 
-/// Decodes the significand and exponent from a single byte.
-///
-/// Returns (`significand`, `exponent`)
-pub fn decode_min_base_fee_factors(factors: u8) -> (u8, u8) {
-    (factors >> 4, factors & 0x0F)
-}
-
-/// Encodes the significand and exponent into a single byte.
-pub fn encode_min_base_fee_factors(significand: u8, exponent: u8) -> u8 {
-    (significand << 4) | (exponent & 0x0F)
-}
-
 /// Decodes the EIP-1559 parameters from `extra_data`,
-/// as well as the minimum base fee factors (significand and exponent).
+/// as well as the minimum base fee.
 ///
-/// Returns (`elasticity`, `denominator`, `significand`, `exponent`)
+/// Returns (`elasticity`, `denominator`, `min_base_fee`)
 pub fn decode_min_base_fee_extra_data(
     extra_data: &[u8],
-) -> Result<(u32, u32, u8, u8), EIP1559ParamError> {
-    if extra_data.len() < 10 {
+) -> Result<(u32, u32, u64), EIP1559ParamError> {
+    if extra_data.len() < 17 {
         return Err(EIP1559ParamError::NoEIP1559Params);
     }
 
@@ -96,25 +84,28 @@ pub fn decode_min_base_fee_extra_data(
     // skip the first version byte
     let denominator: [u8; 4] = extra_data[1..5].try_into().expect("sufficient length");
     let elasticity: [u8; 4] = extra_data[5..9].try_into().expect("sufficient length");
-    let (significand, exponent) = decode_min_base_fee_factors(extra_data[9]);
+    let min_base_fee: [u8; 8] = extra_data[9..17].try_into().expect("sufficient length");
 
-    Ok((u32::from_be_bytes(elasticity), u32::from_be_bytes(denominator), significand, exponent))
+    Ok((
+        u32::from_be_bytes(elasticity),
+        u32::from_be_bytes(denominator),
+        u64::from_be_bytes(min_base_fee),
+    ))
 }
 
 /// Encodes the EIP-1559 parameters for the payload,
-/// as well as the minimum base fee factors (significand and exponent).
+/// as well as the minimum base fee.
 pub fn encode_min_base_fee_extra_data(
     eip_1559_params: B64,
     default_base_fee_params: BaseFeeParams,
-    significand: u8,
-    exponent: u8,
+    min_base_fee: u64,
 ) -> Result<Bytes, EIP1559ParamError> {
-    // 10 bytes: 1 byte for version (1), 8 bytes for eip1559 params, and 1 byte for the minimum base
-    // fee factors (significand and exponent)
-    let mut extra_data = [0u8; 10];
+    // 17 bytes: 1 byte for version (1), 8 bytes for eip1559 params, and 8 byte for the minimum base
+    // fee
+    let mut extra_data = [0u8; 17];
     extra_data[0] = 1;
     encode_eip_1559_params(eip_1559_params, default_base_fee_params, &mut extra_data)?;
-    extra_data[9] = encode_min_base_fee_factors(significand, exponent);
+    extra_data[9..17].copy_from_slice(&min_base_fee.to_be_bytes());
     Ok(Bytes::copy_from_slice(&extra_data))
 }
 
@@ -158,17 +149,22 @@ mod tests {
     fn test_get_extra_data_min_base_fee() {
         let eip_1559_params = B64::from_str("0x0000000800000008").unwrap();
         let extra_data =
-            encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 1, 9);
-        // significand=1, exponent=9: (1 << 4) | 9 -> 16 | 9 = 25
-        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8, 25]));
+            encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 257);
+        assert_eq!(
+            extra_data.unwrap(),
+            Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 1])
+        );
     }
 
     #[test]
     fn test_get_extra_data_min_base_fee_default() {
         let eip_1559_params = B64::ZERO;
         let extra_data =
-            encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 0, 0);
-        // check the version byte is 1 and the min_base_fee_factors is 0
-        assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0]));
+            encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 0);
+        // check the version byte is 1 and the min_base_fee is 0
+        assert_eq!(
+            extra_data.unwrap(),
+            Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0, 0, 0, 0, 0, 0, 0, 0])
+        );
     }
 }

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -66,10 +66,13 @@ pub fn encode_holocene_extra_data(
     Ok(Bytes::copy_from_slice(&extra_data))
 }
 
-/// Decodes the Jovian 1599 parameters from the `extradata` bytes.
+/// Decodes the EIP-1559 parameters from `extra_data`,
+/// as well as the minimum base fee log2.
 ///
 /// Returns (`elasticity`, `denominator`, `min_base_fee_log2`)
-pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u8), EIP1559ParamError> {
+pub fn decode_min_base_fee_extra_data(
+    extra_data: &[u8],
+) -> Result<(u32, u32, u8), EIP1559ParamError> {
     if extra_data.len() < 10 {
         return Err(EIP1559ParamError::NoEIP1559Params);
     }
@@ -86,13 +89,15 @@ pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u8), EIP
     Ok((u32::from_be_bytes(elasticity), u32::from_be_bytes(denominator), min_base_fee_log2))
 }
 
-/// Encodes the Jovian 1599 parameters for the payload
-pub fn encode_jovian_extra_data(
+/// Encodes the EIP-1559 parameters for the payload,
+/// as well as the minimum base fee log2.
+pub fn encode_min_base_fee_extra_data(
     eip_1559_params: B64,
     default_base_fee_params: BaseFeeParams,
     min_base_fee_log2: u8,
 ) -> Result<Bytes, EIP1559ParamError> {
-    // 9 bytes: 1 byte for version (1) and 9 bytes for eip1559 params
+    // 10 bytes: 1 byte for version (1), 8 bytes for eip1559 params, and 1 byte for the minimum base
+    // fee log2
     let mut extra_data = [0u8; 10];
     extra_data[0] = 1;
     encode_eip_1559_params(eip_1559_params, default_base_fee_params, &mut extra_data)?;
@@ -139,7 +144,8 @@ mod tests {
     #[test]
     fn test_get_extra_data_jovian() {
         let eip_1559_params = B64::from_str("0x0000000800000008").unwrap();
-        let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 20);
+        let extra_data =
+            encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 20);
         // check the version byte is 1 and the min_base_fee_log2 is 20
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8, 20]));
     }
@@ -147,7 +153,8 @@ mod tests {
     #[test]
     fn test_get_extra_data_jovian_default() {
         let eip_1559_params = B64::ZERO;
-        let extra_data = encode_jovian_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 0);
+        let extra_data =
+            encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 0);
         // check the version byte is 1 and the min_base_fee_log2 is 0
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0]));
     }

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -142,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_extra_data_jovian() {
+    fn test_get_extra_data_min_base_fee() {
         let eip_1559_params = B64::from_str("0x0000000800000008").unwrap();
         let extra_data =
             encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 20);
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_extra_data_jovian_default() {
+    fn test_get_extra_data_min_base_fee_default() {
         let eip_1559_params = B64::ZERO;
         let extra_data =
             encode_min_base_fee_extra_data(eip_1559_params, BaseFeeParams::new(80, 60), 0);

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -79,7 +79,7 @@ pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EI
     }
 
     if extra_data[0] != JOVIAN_EXTRA_DATA_VERSION_BYTE {
-        // version must be 1: https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md#minimum-base-fee-in-block-header
+        // version must be 1: https://specs.optimism.io/protocol/jovian/exec-engine.html
         return Err(EIP1559ParamError::InvalidVersion(extra_data[0]));
     }
     // skip the first version byte

--- a/crates/consensus/src/eip1559.rs
+++ b/crates/consensus/src/eip1559.rs
@@ -12,6 +12,9 @@ fn encode_eip_1559_params(
     default_base_fee_params: BaseFeeParams,
     extra_data: &mut [u8],
 ) -> Result<(), EIP1559ParamError> {
+    if extra_data.len() < 9 {
+        return Err(EIP1559ParamError::InvalidExtraDataLength);
+    }
     if eip_1559_params.is_zero() {
         let max_change_denominator: u32 = (default_base_fee_params.max_change_denominator)
             .try_into()
@@ -74,8 +77,8 @@ pub fn encode_holocene_extra_data(
 ///
 /// Returns (`elasticity`, `denominator`, `min_base_fee`)
 pub fn decode_jovian_extra_data(extra_data: &[u8]) -> Result<(u32, u32, u64), EIP1559ParamError> {
-    if extra_data.len() < 17 {
-        return Err(EIP1559ParamError::NoEIP1559Params);
+    if extra_data.len() != 17 {
+        return Err(EIP1559ParamError::InvalidExtraDataLength);
     }
 
     if extra_data[0] != JOVIAN_EXTRA_DATA_VERSION_BYTE {
@@ -125,6 +128,9 @@ pub enum EIP1559ParamError {
     /// Elasticity overflow.
     #[error("Elasticity overflow")]
     ElasticityOverflow,
+    /// Extra data is not the correct length.
+    #[error("Extra data is not the correct length")]
+    InvalidExtraDataLength,
 }
 
 #[cfg(test)]

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,7 +24,7 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    encode_holocene_extra_data,
+    decode_jovian_extra_data, encode_holocene_extra_data, encode_jovian_extra_data,
 };
 
 mod source;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,7 +24,8 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    decode_min_base_fee_extra_data, encode_holocene_extra_data, encode_min_base_fee_extra_data,
+    decode_min_base_fee_extra_data, decode_min_base_fee_factors, encode_holocene_extra_data,
+    encode_min_base_fee_extra_data,
 };
 
 mod source;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,7 +24,8 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    decode_jovian_extra_data, encode_holocene_extra_data, encode_jovian_extra_data,
+    decode_jovian_eip_1559_params, decode_jovian_extra_data, encode_holocene_extra_data,
+    encode_jovian_extra_data,
 };
 
 mod source;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,7 +24,7 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    encode_holocene_extra_data, encode_jovian_extra_data,
+    decode_jovian_extra_data, encode_holocene_extra_data, encode_jovian_extra_data,
 };
 
 mod source;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,7 +24,7 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    decode_jovian_extra_data, encode_holocene_extra_data, encode_jovian_extra_data,
+    decode_min_base_fee_extra_data, encode_holocene_extra_data, encode_min_base_fee_extra_data,
 };
 
 mod source;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,8 +24,7 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    decode_jovian_eip_1559_params, decode_jovian_extra_data, encode_holocene_extra_data,
-    encode_jovian_extra_data,
+    encode_holocene_extra_data, encode_jovian_extra_data,
 };
 
 mod source;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,8 +24,7 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    decode_min_base_fee_extra_data, decode_min_base_fee_factors, encode_holocene_extra_data,
-    encode_min_base_fee_extra_data,
+    decode_min_base_fee_extra_data, encode_holocene_extra_data, encode_min_base_fee_extra_data,
 };
 
 mod source;

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -24,7 +24,7 @@ pub use transaction::{
 pub mod eip1559;
 pub use eip1559::{
     EIP1559ParamError, decode_eip_1559_params, decode_holocene_extra_data,
-    decode_min_base_fee_extra_data, encode_holocene_extra_data, encode_min_base_fee_extra_data,
+    decode_jovian_extra_data, encode_holocene_extra_data, encode_jovian_extra_data,
 };
 
 mod source;

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -77,7 +77,7 @@ impl OpPayloadAttributes {
     }
 
     /// Extracts the Jovian 1599 parameters from the encoded form:
-    /// [TODO link design doc]
+    /// <https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md#minimum-base-fee-in-block-header>
     ///
     /// Returns (`elasticity`, `denominator`, `min_base_fee_log2`)
     pub fn decode_jovian_eip_1559_params(&self) -> Option<(u32, u32, u8)> {

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -6,7 +6,7 @@ use alloy_eips::{
     eip1559::BaseFeeParams,
     eip2718::{Eip2718Result, WithEncoded},
 };
-use alloy_primitives::{B64, Bytes, aliases::B96};
+use alloy_primitives::{B64, Bytes, FixedBytes};
 use alloy_rlp::Result;
 use alloy_rpc_types_engine::PayloadAttributes;
 use op_alloy_consensus::{
@@ -44,7 +44,7 @@ pub struct OpPayloadAttributes {
     ///
     /// Prior to Jovian activation, this field should always be [None].
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub jovian_eip_1559_params: Option<B96>,
+    pub jovian_eip_1559_params: Option<FixedBytes<9>>,
 }
 
 impl OpPayloadAttributes {
@@ -263,7 +263,7 @@ mod test {
             no_tx_pool: Some(true),
             gas_limit: Some(42),
             eip_1559_params: None,
-            jovian_eip_1559_params: Some(fixed_bytes!("000000080000000801000000")),
+            jovian_eip_1559_params: Some(fixed_bytes!("000000080000000801")),
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -275,7 +275,7 @@ mod test {
     #[test]
     fn test_get_extra_data_post_jovian() {
         let attributes = OpPayloadAttributes {
-            jovian_eip_1559_params: Some(fixed_bytes!("000000080000000801000000")),
+            jovian_eip_1559_params: Some(fixed_bytes!("000000080000000801")),
             ..Default::default()
         };
         let extra_data = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
@@ -284,8 +284,10 @@ mod test {
 
     #[test]
     fn test_get_extra_data_post_jovian_default() {
-        let attributes =
-            OpPayloadAttributes { jovian_eip_1559_params: Some(B96::ZERO), ..Default::default() };
+        let attributes = OpPayloadAttributes {
+            jovian_eip_1559_params: Some(FixedBytes::ZERO),
+            ..Default::default()
+        };
         let extra_data = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0]));
     }

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -11,7 +11,7 @@ use alloy_rlp::Result;
 use alloy_rpc_types_engine::PayloadAttributes;
 use op_alloy_consensus::{
     EIP1559ParamError, OpTxEnvelope, decode_eip_1559_params, encode_holocene_extra_data,
-    encode_jovian_extra_data,
+    encode_min_base_fee_extra_data,
 };
 
 /// Optimism Payload Attributes
@@ -66,15 +66,14 @@ impl OpPayloadAttributes {
         self.eip_1559_params.map(decode_eip_1559_params)
     }
 
-    /// Encodes the Jovian `eip1559` parameters for the payload, which is the same as the Holocene
-    /// except the version byte is set to 1.
-    pub fn get_jovian_extra_data(
+    /// Encodes the `eip1559` parameters for the payload along with the minimum base fee.
+    pub fn get_min_base_fee_extra_data(
         &self,
         default_base_fee_params: BaseFeeParams,
     ) -> Result<Bytes, EIP1559ParamError> {
         self.eip_1559_params
             .map(|params| {
-                encode_jovian_extra_data(
+                encode_min_base_fee_extra_data(
                     params,
                     default_base_fee_params,
                     self.min_base_fee_log2.unwrap_or(0),
@@ -279,7 +278,7 @@ mod test {
             ..Default::default()
         };
 
-        let extra_data = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
+        let extra_data = attributes.get_min_base_fee_extra_data(BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8, 1]));
     }
 
@@ -291,7 +290,7 @@ mod test {
             ..Default::default()
         };
 
-        let extra_data = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
+        let extra_data = attributes.get_min_base_fee_extra_data(BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap(), Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0]));
     }
 }

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -10,8 +10,8 @@ use alloy_primitives::{B64, Bytes};
 use alloy_rlp::Result;
 use alloy_rpc_types_engine::PayloadAttributes;
 use op_alloy_consensus::{
-    EIP1559ParamError, OpTxEnvelope, decode_eip_1559_params, encode_holocene_extra_data,
-    encode_min_base_fee_extra_data,
+    EIP1559ParamError, OpTxEnvelope, decode_eip_1559_params, decode_min_base_fee_factors,
+    encode_holocene_extra_data, encode_min_base_fee_extra_data,
 };
 
 /// Optimism Payload Attributes
@@ -40,12 +40,13 @@ pub struct OpPayloadAttributes {
     /// Prior to Holocene activation, this field should always be [None].
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub eip_1559_params: Option<B64>,
-    /// If set, this sets the minimum base fee log2 for the block.
+    /// If set, this sets the minimum base fee factors for the block, which contains the
+    /// significand (4 bits) and exponent (4 bits) packed into a single byte.
     ///
     /// Prior to having the configurable minimum base fee enabled, this field should always be
     /// [None].
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub min_base_fee_log2: Option<u8>,
+    pub min_base_fee_factors: Option<u8>,
 }
 
 impl OpPayloadAttributes {
@@ -72,12 +73,15 @@ impl OpPayloadAttributes {
         &self,
         default_base_fee_params: BaseFeeParams,
     ) -> Result<Bytes, EIP1559ParamError> {
+        let (significand, exponent) =
+            self.min_base_fee_factors.map(decode_min_base_fee_factors).unwrap_or_default();
         self.eip_1559_params
             .map(|params| {
                 encode_min_base_fee_extra_data(
                     params,
                     default_base_fee_params,
-                    self.min_base_fee_log2.unwrap_or(0),
+                    significand,
+                    exponent,
                 )
             })
             .ok_or(EIP1559ParamError::NoEIP1559Params)?
@@ -175,7 +179,7 @@ mod test {
             no_tx_pool: Some(true),
             gas_limit: Some(42),
             eip_1559_params: None,
-            min_base_fee_log2: None,
+            min_base_fee_factors: None,
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -198,7 +202,7 @@ mod test {
             no_tx_pool: Some(true),
             gas_limit: Some(42),
             eip_1559_params: Some(b64!("0000dead0000beef")),
-            min_base_fee_log2: None,
+            min_base_fee_factors: None,
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -239,7 +243,7 @@ mod test {
             no_tx_pool: Some(true),
             gas_limit: Some(42),
             eip_1559_params: Some(b64!("0000dead0000beef")),
-            min_base_fee_log2: None,
+            min_base_fee_factors: None,
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -262,7 +266,7 @@ mod test {
             no_tx_pool: Some(true),
             gas_limit: Some(42),
             eip_1559_params: None,
-            min_base_fee_log2: Some(1),
+            min_base_fee_factors: Some(1),
         };
 
         let ser = serde_json::to_string(&attributes).unwrap();
@@ -275,7 +279,7 @@ mod test {
     fn test_get_extra_data_post_min_base_fee() {
         let attributes = OpPayloadAttributes {
             eip_1559_params: Some(B64::from_str("0x0000000800000008").unwrap()),
-            min_base_fee_log2: Some(1),
+            min_base_fee_factors: Some(1),
             ..Default::default()
         };
 
@@ -287,7 +291,7 @@ mod test {
     fn test_get_extra_data_post_min_base_fee_default() {
         let attributes = OpPayloadAttributes {
             eip_1559_params: Some(B64::ZERO),
-            min_base_fee_log2: Some(0),
+            min_base_fee_factors: Some(0),
             ..Default::default()
         };
 

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -42,7 +42,8 @@ pub struct OpPayloadAttributes {
     pub eip_1559_params: Option<B64>,
     /// If set, this sets the minimum base fee log2 for the block.
     ///
-    /// Prior to Jovian activation, this field should always be [None].
+    /// Prior to having the configurable minimum base fee enabled, this field should always be
+    /// [None].
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub min_base_fee_log2: Option<u8>,
 }
@@ -225,7 +226,7 @@ mod test {
     }
 
     #[test]
-    fn test_serde_roundtrip_attributes_pre_jovian() {
+    fn test_serde_roundtrip_attributes_pre_min_base_fee() {
         let attributes = OpPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 0x1337,
@@ -248,7 +249,7 @@ mod test {
     }
 
     #[test]
-    fn test_serde_roundtrip_attributes_post_jovian() {
+    fn test_serde_roundtrip_attributes_post_min_base_fee() {
         let attributes = OpPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 0x1337,
@@ -271,7 +272,7 @@ mod test {
     }
 
     #[test]
-    fn test_get_extra_data_post_jovian() {
+    fn test_get_extra_data_post_min_base_fee() {
         let attributes = OpPayloadAttributes {
             eip_1559_params: Some(B64::from_str("0x0000000800000008").unwrap()),
             min_base_fee_log2: Some(1),
@@ -283,7 +284,7 @@ mod test {
     }
 
     #[test]
-    fn test_get_extra_data_post_jovian_default() {
+    fn test_get_extra_data_post_min_base_fee_default() {
         let attributes = OpPayloadAttributes {
             eip_1559_params: Some(B64::ZERO),
             min_base_fee_log2: Some(0),

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -11,7 +11,7 @@ use alloy_rlp::Result;
 use alloy_rpc_types_engine::PayloadAttributes;
 use op_alloy_consensus::{
     EIP1559ParamError, OpTxEnvelope, decode_eip_1559_params, encode_holocene_extra_data,
-    encode_min_base_fee_extra_data,
+    encode_jovian_extra_data,
 };
 
 /// Optimism Payload Attributes
@@ -42,8 +42,7 @@ pub struct OpPayloadAttributes {
     pub eip_1559_params: Option<B64>,
     /// If set, this sets the minimum base fee for the block.
     ///
-    /// Prior to having the configurable minimum base fee enabled, this field should always be
-    /// [None].
+    /// Prior to Jovian activation, this field should always be [None].
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub min_base_fee: Option<u64>,
 }
@@ -68,13 +67,13 @@ impl OpPayloadAttributes {
     }
 
     /// Encodes the `eip1559` parameters for the payload along with the minimum base fee.
-    pub fn get_min_base_fee_extra_data(
+    pub fn get_jovian_extra_data(
         &self,
         default_base_fee_params: BaseFeeParams,
     ) -> Result<Bytes, EIP1559ParamError> {
         self.eip_1559_params
             .map(|params| {
-                encode_min_base_fee_extra_data(
+                encode_jovian_extra_data(
                     params,
                     default_base_fee_params,
                     self.min_base_fee.unwrap_or_default(),
@@ -279,7 +278,7 @@ mod test {
             ..Default::default()
         };
 
-        let extra_data = attributes.get_min_base_fee_extra_data(BaseFeeParams::new(80, 60));
+        let extra_data = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
         assert_eq!(
             extra_data.unwrap(),
             Bytes::copy_from_slice(&[1, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 1])
@@ -294,7 +293,7 @@ mod test {
             ..Default::default()
         };
 
-        let extra_data = attributes.get_min_base_fee_extra_data(BaseFeeParams::new(80, 60));
+        let extra_data = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
         assert_eq!(
             extra_data.unwrap(),
             Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0, 0, 0, 0, 0, 0, 0, 0])

--- a/crates/rpc-types-engine/src/attributes.rs
+++ b/crates/rpc-types-engine/src/attributes.rs
@@ -53,6 +53,9 @@ impl OpPayloadAttributes {
         &self,
         default_base_fee_params: BaseFeeParams,
     ) -> Result<Bytes, EIP1559ParamError> {
+        if self.min_base_fee.is_some() {
+            return Err(EIP1559ParamError::MinBaseFeeMustBeNone);
+        }
         self.eip_1559_params
             .map(|params| encode_holocene_extra_data(params, default_base_fee_params))
             .ok_or(EIP1559ParamError::NoEIP1559Params)?
@@ -71,12 +74,15 @@ impl OpPayloadAttributes {
         &self,
         default_base_fee_params: BaseFeeParams,
     ) -> Result<Bytes, EIP1559ParamError> {
+        if self.min_base_fee.is_none() {
+            return Err(EIP1559ParamError::MinBaseFeeNotSet);
+        }
         self.eip_1559_params
             .map(|params| {
                 encode_jovian_extra_data(
                     params,
                     default_base_fee_params,
-                    self.min_base_fee.unwrap_or_default(),
+                    self.min_base_fee.unwrap(),
                 )
             })
             .ok_or(EIP1559ParamError::NoEIP1559Params)?
@@ -225,7 +231,7 @@ mod test {
     }
 
     #[test]
-    fn test_serde_roundtrip_attributes_pre_min_base_fee() {
+    fn test_serde_roundtrip_attributes_pre_jovian() {
         let attributes = OpPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 0x1337,
@@ -248,7 +254,7 @@ mod test {
     }
 
     #[test]
-    fn test_serde_roundtrip_attributes_post_min_base_fee() {
+    fn test_serde_roundtrip_attributes_post_jovian() {
         let attributes = OpPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 0x1337,
@@ -271,7 +277,7 @@ mod test {
     }
 
     #[test]
-    fn test_get_extra_data_post_min_base_fee() {
+    fn test_get_extra_data_post_jovian() {
         let attributes = OpPayloadAttributes {
             eip_1559_params: Some(B64::from_str("0x0000000800000008").unwrap()),
             min_base_fee: Some(257),
@@ -286,7 +292,7 @@ mod test {
     }
 
     #[test]
-    fn test_get_extra_data_post_min_base_fee_default() {
+    fn test_get_extra_data_post_jovian_default() {
         let attributes = OpPayloadAttributes {
             eip_1559_params: Some(B64::ZERO),
             min_base_fee: Some(0),
@@ -298,5 +304,30 @@ mod test {
             extra_data.unwrap(),
             Bytes::copy_from_slice(&[1, 0, 0, 0, 80, 0, 0, 0, 60, 0, 0, 0, 0, 0, 0, 0, 0])
         );
+    }
+
+    #[test]
+    fn test_get_jovian_extra_data_fails_without_min_base_fee() {
+        let attributes = OpPayloadAttributes {
+            eip_1559_params: Some(B64::from_str("0x0000000800000008").unwrap()),
+            min_base_fee: None,
+            ..Default::default()
+        };
+
+        let result = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
+        assert_eq!(result.unwrap_err(), EIP1559ParamError::MinBaseFeeNotSet);
+    }
+
+    #[test]
+    fn test_min_base_fee_must_be_none_before_jovian() {
+        let attributes = OpPayloadAttributes {
+            eip_1559_params: Some(B64::from_str("0x0000000800000008").unwrap()),
+            min_base_fee: Some(100),
+            ..Default::default()
+        };
+
+        // Use Holocene function for pre-Jovian decoding of extra data
+        let result = attributes.get_holocene_extra_data(BaseFeeParams::new(80, 60));
+        assert_eq!(result.unwrap_err(), EIP1559ParamError::MinBaseFeeMustBeNone);
     }
 }

--- a/crates/rpc-types/src/genesis.rs
+++ b/crates/rpc-types/src/genesis.rs
@@ -242,7 +242,8 @@ mod tests {
           "ecotoneTime": 0,
           "fjordTime": 0,
           "graniteTime": 0,
-          "holoceneTime": 0
+          "holoceneTime": 0,
+          "jovianTime": 0
         }
         "#;
 
@@ -262,7 +263,7 @@ mod tests {
                     holocene_time: Some(0),
                     isthmus_time: None,
                     interop_time: None,
-                    jovian_time: None,
+                    jovian_time: Some(0),
                 }),
                 base_fee_info: None,
             }

--- a/crates/rpc-types/src/genesis.rs
+++ b/crates/rpc-types/src/genesis.rs
@@ -243,6 +243,7 @@ mod tests {
           "fjordTime": 0,
           "graniteTime": 0,
           "holoceneTime": 0,
+          "isthmusTime": 0,
           "jovianTime": 0
         }
         "#;
@@ -261,7 +262,7 @@ mod tests {
                     fjord_time: Some(0),
                     granite_time: Some(0),
                     holocene_time: Some(0),
-                    isthmus_time: None,
+                    isthmus_time: Some(0),
                     interop_time: None,
                     jovian_time: Some(0),
                 }),


### PR DESCRIPTION
<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This PR implements the `extraData` section of the [design doc](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md#minimum-base-fee-in-block-header) of adding configurable minimum base fee for the OP Stack. 

Introducing a minimum base fee reduces of the chances of encountering priority fee auctions which occur when the block is almost at the gas limit, as well as cases where batcher sequencer throttling is happening where it intentionally processes fewer transactions to avoid a backlog of batches. 

Furthermore, when the base fee is at a near minimum (i.e., 1 wei), the number of doublings it takes is too long to catch up with the fee market demand.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

By setting a minimum base fee, we reduce the time and the number of doublings needed. See the table on the time saved on [OP Mainnet in minutes](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/minimum-base-fee.md#minimum-base-fee-in-block-header).

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
